### PR TITLE
docs: make sidebar collapsed by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,8 @@ params:
     footer_about_disable: false
     navbar_logo: true
     navbar_translucent_over_cover_disable: false
-    sidebar_menu_compact: false
+    sidebar_menu_compact: true
+    sidebar_menu_foldable: true
     sidebar_search_disable: true
     feedback:
       enable: false


### PR DESCRIPTION
This PR collapses the sidebar navigation so that there's not so much going on when you first hit the docs page.