### PR TITLE
docs: update cluster templates references

### DIFF
--- a/content/docs/how-to-guides/how-to-expose-http-service-from-a-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-expose-http-service-from-a-cluster/index.md
@@ -22,6 +22,12 @@ If you have an existing cluster, simply check the checkbox in the features secti
 {{< imgproc 2.png Resize "900x" >}}
 {{< /imgproc >}}
 
+If you are using cluster templates, you can enable the feature by adding the following to the cluster template YAML:
+```yaml
+features:
+  enableWorkloadProxy: true
+```
+
 You will notice that the "Exposed Services" section will appear on the left menu for the cluster the feature is enabled on.
 
 ## Exposing a Kubernetes Service


### PR DESCRIPTION
Update the cluster template reference docs to include:
- `updateStrategy` and `deleteStrategy` reference
- `features` section

Also mention the cluster templates option in the "How to Expose an HTTP Service from a Cluster" document.