### PR TITLE
docs: add example of default omni directory

### DIFF
--- a/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
+++ b/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
@@ -22,6 +22,12 @@ This guide assumes the downloaded binary is named `omnictl`.
 Add the downloaded `omniconfig.yaml` to the default location to use it with `omnictl`:
 
 ```bash
+cp omniconfig.yaml ~/.config/omni/config
+```
+
+If you would like to merge the `omniconfig.yaml` with an existing configuration, use the following command:
+
+```bash
 omnictl config merge ./omniconfig.yaml
 ```
 


### PR DESCRIPTION
Used for customers who want to manually manage the config