### PR TITLE
chore: remove docker socket references

### DIFF
--- a/content/docs/how-to-guides/how-to-deploy-omni-on-prem/index.md
+++ b/content/docs/how-to-guides/how-to-deploy-omni-on-prem/index.md
@@ -129,7 +129,6 @@ docker run \
   --net=host \
   --cap-add=NET_ADMIN \
   -v $PWD/etcd:/_out/etcd \
-  -v /var/run/docker.sock:/var/run/docker.sock \
   -v <path to TLS certificate>:/tls.crt \
   -v <path to TLS key>:/tls.key \
   -v $PWD/omni.asc:/omni.asc \
@@ -172,7 +171,6 @@ docker run \
   --net=host \
   --cap-add=NET_ADMIN \
   -v $PWD/etcd:/_out/etcd \
-  -v /var/run/docker.sock:/var/run/docker.sock \
   -v <path to full chain TLS certificate>:/tls.crt \
   -v <path to TLS key>:/tls.key \
   -v $PWD/omni.asc:/omni.asc \

--- a/content/docs/tutorials/install-airgapped-omni.md
+++ b/content/docs/tutorials/install-airgapped-omni.md
@@ -397,7 +397,6 @@ sudo docker run \
   --net=host \
   --cap-add=NET_ADMIN \
   -v $PWD/etcd:/_out/etcd \
-  -v /var/run/docker.sock:/var/run/docker.sock \
   -v $PWD/certs/fullchain.pem:/fullchain.pem \
   -v $PWD/certs/privkey.pem:/privkey.pem \
   -v $PWD/certs/omni.asc:/omni.asc \


### PR DESCRIPTION
Remove the references to Omni needing to mount the Docker socket when run as a container as it isn't required or used any more.