### PR TITLE
docs: update how-tos to remove "How to" from title

### DIFF
--- a/content/docs/how-to-guides/how-to-add-saml-users/index.md
+++ b/content/docs/how-to-guides/how-to-add-saml-users/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Add a User to Omni with SAML Enabled"
+title: "Add a User to Omni with SAML Enabled"
 description: "A guide on how to add a user to Omni with SAML authentication enabled."
 draft: false
 weight: 60

--- a/content/docs/how-to-guides/how-to-auto-assign-roles-to-saml-users/index.md
+++ b/content/docs/how-to-guides/how-to-auto-assign-roles-to-saml-users/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to auto-assign roles to SAML users"
+title: "Auto-assign roles to SAML users"
 description: "A guide on how to assign Omni roles to SAML users automatically."
 draft: false
 weight: 60

--- a/content/docs/how-to-guides/how-to-back-up-on-prem-omni-db.md
+++ b/content/docs/how-to-guides/how-to-back-up-on-prem-omni-db.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Back Up On-prem Omni Database"
+title: "Back Up On-prem Omni Database"
 date: 2022-12-28T10:00:00+01:00
 draft: false
 weight: 210

--- a/content/docs/how-to-guides/how-to-configure-entraid-for-omni.md
+++ b/content/docs/how-to-guides/how-to-configure-entraid-for-omni.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Configure Entra ID AD for Omni"
+title: "Configure Entra ID AD for Omni"
 draft: false
 weight: 230
 ---
@@ -14,9 +14,9 @@ Under the "Manage" section of the application, select "Single sign-on", then "SA
 
 In section 1 of this form, enter identifier, reply, and sign on URLs that match the following and save:
 
-  - Identifier (Entity ID): `https://<domain name for omni>/saml/metadata`
-  - Reply URL (Assertion Consumer Service URL): `https://<domain name for omni>/saml/acs`
-  - Sign on URL: `https://<domain name for omni>/login`
+- Identifier (Entity ID): `https://<domain name for omni>/saml/metadata`
+- Reply URL (Assertion Consumer Service URL): `https://<domain name for omni>/saml/acs`
+- Sign on URL: `https://<domain name for omni>/login`
 
 From section 3, copy the "App Federation Metadata Url" for later use.
 

--- a/content/docs/how-to-guides/how-to-configure-keycloak-for-omni/_index.md
+++ b/content/docs/how-to-guides/how-to-configure-keycloak-for-omni/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Configure Keycloak for Omni"
+title: "Configure Keycloak for Omni"
 draft: false
 weight: 220
 ---
@@ -9,7 +9,6 @@ weight: 220
 2. Create a realm.
 
 - In the upper left corner of the page, select the dropdown where it says **master**
-
 
 {{< imgproc keycloak_001.png Resize "900x" >}}
 {{< /imgproc >}}
@@ -22,7 +21,7 @@ weight: 220
 3. Find the realm metadata.
 
 - In the realm settings, there is a link to the metadata needed for SAML under Endpoints.
-    - Copy the link or save the data to a file. It will be needed for the installation of Omni.
+  - Copy the link or save the data to a file. It will be needed for the installation of Omni.
 
 {{< imgproc keycloak_003.png Resize "900x" >}}
 {{< /imgproc >}}
@@ -35,24 +34,24 @@ weight: 220
 {{< /imgproc >}}
 
 - Fill in the **General Settings** as shown in the example below. **Replace the hostname in the example with your own Omni hostname or IP**.
-    - Client type
-    - Client ID
-    - Name
+  - Client type
+  - Client ID
+  - Name
 
 {{< imgproc keycloak_005.png Resize "900x" >}}
 {{< /imgproc >}}
 
 - Fill in the **Login settings** as shown in the example below. **Replace the hostname in the example with your own Omni hostname or IP**.
-    - Root URL
-    - Valid redirect URIs
-    - Master SAML PRocessing URL
+  - Root URL
+  - Valid redirect URIs
+  - Master SAML PRocessing URL
 
 {{< imgproc keycloak_006.png Resize "900x" >}}
 {{< /imgproc >}}
 
 - Modify the **Signature and Encryption** settings.
-    - Sign documents: **off**
-    - Sign assertions: **on**
+  - Sign documents: **off**
+  - Sign assertions: **on**
 
 {{< imgproc keycloak_007.png Resize "900x" >}}
 {{< /imgproc >}}
@@ -67,21 +66,21 @@ weight: 220
 {{< imgproc keycloak_009.png Resize "900x" >}}
 {{< /imgproc >}}
 
-- Select **Add predefined mapper**. 
+- Select **Add predefined mapper**.
 
 {{< imgproc keycloak_010.png Resize "900x" >}}
 {{< /imgproc >}}
 
 - The following mappers need to be added because they will be used by Omni will use these attributes for assigning permissions.
-    - X500 email
-    - X500 givenName
-    - X500 surname
+  - X500 email
+  - X500 givenName
+  - X500 surname
 
 {{< imgproc keycloak_011.png Resize "900x" >}}
 {{< /imgproc >}}
 
 - Add a new user (optional)
-    - If Keycloak is being used as an Identity Provider, users can be created here.
+  - If Keycloak is being used as an Identity Provider, users can be created here.
 
 {{< imgproc keycloak_012.png Resize "900x" >}}
 {{< /imgproc >}}
@@ -95,3 +94,4 @@ weight: 220
 
 {{< imgproc keycloak_014.png Resize "900x" >}}
 {{< /imgproc >}}
+

--- a/content/docs/how-to-guides/how-to-configure-okta-for-omni/_index.md
+++ b/content/docs/how-to-guides/how-to-configure-okta-for-omni/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Configure Okta for Omni"
+title: "Configure Okta for Omni"
 draft: false
 weight: 240
 ---

--- a/content/docs/how-to-guides/how-to-create-a-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-create-a-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Cluster"
+title: "Create a Cluster"
 description: "A guide on how to create a cluster."
 date: 2022-10-30T15:50:38-07:00
 draft: false

--- a/content/docs/how-to-guides/how-to-create-a-hybrid-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-create-a-hybrid-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Create a Hybrid Cluster
+title: Create a Hybrid Cluster
 description: "A guide on how to create a hybrid cluster."
 date: 2022-10-29T09:33:42-07:00
 draft: false
@@ -10,7 +10,6 @@ This guide shows you how to create and configure a cluster consisting of machine
 
 Refer to the general guide on creating a cluster to get started.
 To create a hybid cluster apply the following cluster patch by clicking on "Config Patches" and navigating the the "Cluster" tab:
-
 
 {{< imgproc how-to-create-a-hybrid-cluster-1.png Resize "900x" >}}
 {{< /imgproc >}}

--- a/content/docs/how-to-guides/how-to-create-a-service-account/index.md
+++ b/content/docs/how-to-guides/how-to-create-a-service-account/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create an Omni Service Account"
+title: "Create an Omni Service Account"
 description: "A guide on how to create an Omni service account."
 date: 2023-07-03T00:00:00Z
 draft: false

--- a/content/docs/how-to-guides/how-to-create-etcd-backups/index.md
+++ b/content/docs/how-to-guides/how-to-create-etcd-backups/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create Etcd Backups"
+title: "Create Etcd Backups"
 date: 2023-11-11T07:00:00-07:00
 description: "A guide on how to create cluster etcd backups using Omni."
 draft: false
@@ -22,7 +22,7 @@ ephemeral   EtcdBackupOverallStatus   etcdbackup-overall-status   1         s3  
 ```
 
 The combination of the `CONFIGURATION NAME` and `CONFIGURATION ERROR` fields display the current backup store configuration status.
-Currently, Omni supports two backup stores: `local` and `s3`. 
+Currently, Omni supports two backup stores: `local` and `s3`.
 These are configured during Omni initialization.
 The output above indicates that the backup store is set to use the `s3` store.
 However, the s3 configuration itself has not yet been added, so the` CONFIGURATION ERROR` field shows `not initialized`.
@@ -31,7 +31,7 @@ The rest of the fields show as empty because no backups have been created yet.
 ### S3 configuration
 
 To use S3 as the backup storage, you will first need to configure the S3 credentials for Omni to use.
-This can be done by creating an `EtcdBackupS3Configs.omni.sidero.dev` resource in Omni. 
+This can be done by creating an `EtcdBackupS3Configs.omni.sidero.dev` resource in Omni.
 Below is an example for Minio S3:
 
 ```yaml
@@ -49,14 +49,15 @@ spec:
 ```
 
 Let's go through the fields:
+
 - `bucket` - the name of the S3 bucket for storing backups. This is the only field required in all cases.
 - `region` - the region of the S3 bucket. If not provided, Omni will use the default region.
 - `endpoint` - the S3 endpoint. If not provided, Omni will use the default AWS S3 endpoint.
-- `accesskeyid` and `secretaccesskey` - the credentials to access the S3 bucket. If not provided, 
+- `accesskeyid` and `secretaccesskey` - the credentials to access the S3 bucket. If not provided,
   Omni will assume it runs in an EC2 instance with an IAM role that has access to the specified S3 bucket.
 - `sessiontoken` - the session token (if any) for accessing the S3 bucket.
 
-Save it as `<file-name>.yaml` and apply using `omnictl apply -f <file-name>.yaml`. 
+Save it as `<file-name>.yaml` and apply using `omnictl apply -f <file-name>.yaml`.
 During resource creation, Omni will validate the provided credentials by attempting to list the objects in the bucket.
 It will return an error if the validation fails and will not update the resource.
 
@@ -98,45 +99,45 @@ This command print per-cluster backup status. The output will be similar to this
 
 ```yaml
 metadata:
-    namespace: ephemeral
-    type: EtcdBackupStatuses.omni.sidero.dev
-    id: <cluster-name>
-    version: 1
-    owner: EtcdBackupController
-    phase: running
+  namespace: ephemeral
+  type: EtcdBackupStatuses.omni.sidero.dev
+  id: <cluster-name>
+  version: 1
+  owner: EtcdBackupController
+  phase: running
 spec:
-    status: 1
-    error: ""
-    lastbackuptime:
-        seconds: 1702166400
-        nanos: 985220192
-    lastbackupattempt:
-        seconds: 1702166400
-        nanos: 985220192
+  status: 1
+  error: ""
+  lastbackuptime:
+    seconds: 1702166400
+    nanos: 985220192
+  lastbackupattempt:
+    seconds: 1702166400
+    nanos: 985220192
 ```
 
 You can also get the overall status of the backup subsystem, where the output will be similar to this:
 
 ```yaml
 metadata:
-    namespace: ephemeral
-    type: EtcdBackupOverallStatuses.omni.sidero.dev
-    id: etcdbackup-overall-status
-    version: 3
-    owner: EtcdBackupOverallStatusController
-    phase: running
+  namespace: ephemeral
+  type: EtcdBackupOverallStatuses.omni.sidero.dev
+  id: etcdbackup-overall-status
+  version: 3
+  owner: EtcdBackupOverallStatusController
+  phase: running
 spec:
-    configurationname: s3
-    configurationerror: ""
-    lastbackupstatus:
-        status: 1
-        error: ""
-        lastbackuptime:
-            seconds: 1702166400
-            nanos: 985220192
-        lastbackupattempt:
-            seconds: 1702166400
-            nanos: 985220192
+  configurationname: s3
+  configurationerror: ""
+  lastbackupstatus:
+    status: 1
+    error: ""
+    lastbackuptime:
+      seconds: 1702166400
+      nanos: 985220192
+    lastbackupattempt:
+      seconds: 1702166400
+      nanos: 985220192
 ```
 
 ### Automatic backup
@@ -175,7 +176,7 @@ Your machine UUIDs will likely be different, and the Kubernetes and Talos versio
 You will need both of these, as well as the cluster name, in your cluster template.
 To obtain these, refer to the `clustermachinestatus` and `cluster` resources.
 
-In this example, we are going to set the backup interval for the cluster to one hour. Save this template 
+In this example, we are going to set the backup interval for the cluster to one hour. Save this template
 as `<file-name>.yaml`. Before applying this change, we want to ensure that no automatic backup is enabled for this
 cluster. To do that, let's run the following command:
 

--- a/content/docs/how-to-guides/how-to-create-kubernetes-service-account/index.md
+++ b/content/docs/how-to-guides/how-to-create-kubernetes-service-account/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Service Account Kubeconfig"
+title: "Create a Service Account Kubeconfig"
 description: "A guide on how to create a service account kubeconfig in Omni."
 date: 2023-02-24T00:00:00Z
 draft: false
@@ -28,6 +28,5 @@ Replace `<user>` with any value you would like.
 {{% /alert %}}
 
 This command will create a service account token with the given username and obtain a kubeconfig file for the given cluster and username.
-
 
 You can now use `kubectl` with the generated kubeconfig.

--- a/content/docs/how-to-guides/how-to-create-machine-classes/index.md
+++ b/content/docs/how-to-guides/how-to-create-machine-classes/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Machine Class"
+title: "Create a Machine Class"
 description: "A guide on how to create a machine class."
 date: 2023-10-25T17:19:38+04:00
 draft: false
@@ -49,7 +49,6 @@ Click "Create Machine Class".
 {{< imgproc 7.png Resize "900x" >}}
 {{< /imgproc >}}
 
-
 {{% /tab %}}
 
 {{% tab header="CLI" %}}
@@ -58,15 +57,13 @@ Create a file called `machine-class.yaml` with the following content:
 
 ```yaml
 metadata:
-    namespace: default
-    type: MachineClasses.omni.sidero.dev
-    id: test
+  namespace: default
+  type: MachineClasses.omni.sidero.dev
+  id: test
 spec:
-    matchlabels:
-                                                                # match machines:
-        - omni.sidero.dev/arch: amd64, omni.sidero.dev/cpus > 2 # with arch == amd64 and > 2 CPUs
-                                                                # or
-        - omni.sidero.dev/arch: arm64, omni.sidero.dev/cpus > 4 # with arch == amd64 and > 4 CPUs
+  matchlabels:
+    # matches machines with amd64 architecture and more than 2 CPUs
+    - omni.sidero.dev/arch: amd64, omni.sidero.dev/cpus > 2
 ```
 
 Create the machine class:

--- a/content/docs/how-to-guides/how-to-deploy-omni-on-prem/index.md
+++ b/content/docs/how-to-guides/how-to-deploy-omni-on-prem/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Deploy Omni On-prem"
+title: "Deploy Omni On-prem"
 date: 2022-11-17T13:06:13-08:00
 draft: false
 weight: 200

--- a/content/docs/how-to-guides/how-to-enable-disk-encryption/index.md
+++ b/content/docs/how-to-guides/how-to-enable-disk-encryption/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Enable Disk Encryption"
+title: "Enable Disk Encryption"
 description: "A guide on how to enable Omni KMS assisted disk encryption for a cluster."
 date: 2022-10-30T15:50:38-07:00
 draft: false

--- a/content/docs/how-to-guides/how-to-export-cluster-template/index.md
+++ b/content/docs/how-to-guides/how-to-export-cluster-template/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Export a Cluster Template from a Cluster Created in the UI"
+title: "Export a Cluster Template from a Cluster Created in the UI"
 description: "A guide on how to export a cluster template from a cluster created in the UI."
 draft: false
 weight: 60

--- a/content/docs/how-to-guides/how-to-expose-http-service-from-a-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-expose-http-service-from-a-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Expose an HTTP Service from a Cluster"
+title: "Expose an HTTP Service from a Cluster"
 description: "A guide on how to expose am HTTP service from a cluster for external access."
 date: 2023-08-10T00:00:00Z
 draft: false
@@ -23,6 +23,7 @@ If you have an existing cluster, simply check the checkbox in the features secti
 {{< /imgproc >}}
 
 If you are using cluster templates, you can enable the feature by adding the following to the cluster template YAML:
+
 ```yaml
 features:
   enableWorkloadProxy: true
@@ -74,11 +75,13 @@ spec:
 ```
 
 Apply it to the cluster:
+
 ```bash
 kubectl apply -f nginx.yaml
 ```
 
 Note the following annotations on the cluster:
+
 ```yaml
 omni-kube-service-exposer.sidero.dev/port: "50080"
 omni-kube-service-exposer.sidero.dev/label: Sample Nginx
@@ -96,10 +99,12 @@ If not set, the default name of `<service-name>.<service-namespace>` will be use
 The annotation `omni-kube-service-exposer.sidero.dev/icon` can be set to render an icon for this service on the Omni Web left menu.
 
 If set, valid values are:
+
 - Either a base64-encoded SVG
 - Or a base64-encoded GZIP of an SVG
 
 To encode an SVG file `icon.svg` to be used for the annotation, you can use the following command:
+
 ```bash
 gzip -c icon.svg | base64
 ```

--- a/content/docs/how-to-guides/how-to-file-an-issue/index.md
+++ b/content/docs/how-to-guides/how-to-file-an-issue/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to File an Issue"
+title: "File an Issue"
 description: "A guide on how to file an issue for Omni."
 weight: 50
 ---
@@ -17,3 +17,4 @@ Now, click on the "New issue" button:
 {{< /imgproc >}}
 
 Choose the issue type, fill in the details, and submit the issue.
+

--- a/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
+++ b/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Install and Configure Omnictl
+title: Install and Configure Omnictl
 description: "A guide on installing and configuring `omnictl` for Omni."
 date: 2023-01-30T00:00:00Z
 draft: false

--- a/content/docs/how-to-guides/how-to-install-talosctl.md
+++ b/content/docs/how-to-guides/how-to-install-talosctl.md
@@ -1,5 +1,5 @@
 ---
-title: "How to install talosctl"
+title: "Install talosctl"
 description: "A guide on how to install talosctl."
 weight: 50
 ---
@@ -13,3 +13,4 @@ curl -sL https://talos.dev/install | sh
 ```
 
 You now have `talosctl` installed.
+

--- a/content/docs/how-to-guides/how-to-manage-acls.md
+++ b/content/docs/how-to-guides/how-to-manage-acls.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Manage Access Policies (ACLs)"
+title: "Manage Access Policies (ACLs)"
 description: "A guide on how to manage Omni ACLs."
 #date: 2023-05-28T12:00:00Z
 weight: 50
@@ -79,7 +79,6 @@ Only the users who have the Omni role `Admin` can manage ACLs.
 Users who have the Omni role `Operator` or above are assigned to the Kubernetes role `system:masters` by default, in addition to the ACLs.
 {{% /alert %}}
 
-
 ## Create Kubernetes RBAC resources
 
 Locally, create `rbac.yaml` with a `Namespace` called `my-app`, and a `Role` & `RoleBinding` to give access to the `my-app-read-only` group:
@@ -116,6 +115,7 @@ subjects:
 ```
 
 As the cluster admin, apply the manifests to the Kubernetes cluster `production`:
+
 ```bash
 kubectl apply -f rbac.yaml
 ```

--- a/content/docs/how-to-guides/how-to-patch-a-control-plane/index.md
+++ b/content/docs/how-to-guides/how-to-patch-a-control-plane/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Patch For Cluster Control Planes"
+title: "Create a Patch For Cluster Control Planes"
 description: "A guide on how to create a config patch for the control plane of a cluster."
 draft: false
 weight: 60
@@ -32,3 +32,4 @@ Click "Save" to create the config patch:
 
 {{< imgproc 5.png Resize "900x" >}}
 {{< /imgproc >}}
+

--- a/content/docs/how-to-guides/how-to-patch-a-machine/index.md
+++ b/content/docs/how-to-guides/how-to-patch-a-machine/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Patch For Cluster Machines"
+title: "Create a Patch For Cluster Machines"
 description: "A guide on how to create a config patch for a machine in a cluster."
 draft: false
 weight: 60
@@ -32,3 +32,4 @@ Click "Save" to create the config patch:
 
 {{< imgproc 5.png Resize "900x" >}}
 {{< /imgproc >}}
+

--- a/content/docs/how-to-guides/how-to-patch-a-worker/index.md
+++ b/content/docs/how-to-guides/how-to-patch-a-worker/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Create a Patch For Cluster Workers"
+title: "Create a Patch For Cluster Workers"
 description: "A guide on how to create a config patch for the worker machine set of a cluster."
 draft: false
 weight: 60
@@ -32,3 +32,4 @@ Click "Save" to create the config patch:
 
 {{< imgproc 5.png Resize "900x" >}}
 {{< /imgproc >}}
+

--- a/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-iso/index.md
+++ b/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-iso/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Register a Bare Metal Machine (ISO)
+title: Register a Bare Metal Machine (ISO)
 description: "A guide on how to register bare metal machines with Omni using an ISO."
 date: 2022-10-29T09:38:16-07:00
 draft: false
@@ -61,7 +61,6 @@ sdb      8:0    0 39.1G  0 disk
 ```
 
 In this example `sdb` is the USB drive.
-
 
 ```bash
 dd if=<path to ISO> of=/dev/sdb conv=fdatasync

--- a/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-pxe/index.md
+++ b/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-pxe/index.md
@@ -1,10 +1,11 @@
 ---
-title: How to Register a Bare Metal Machine (PXE/iPXE)
+title: Register a Bare Metal Machine (PXE/iPXE)
 description: "A guide on how to register a bare metal machines with Omni using PXE/iPXE."
 date: 2022-11-15T15:55:21-08:00
 draft: false
 weight: 20
 ---
+
 This guide shows you how to register a bare metal machine with Omni by PXE/iPXE booting.
 
 ## Copy the Required Kernel Parameters
@@ -52,7 +53,6 @@ Place the following in `/var/lib/matchbox/profiles/default.json`:
 
 Update `siderolink.api`, `talos.events.sink`, and `talos.logging.kernel` with the kerenl parameters copied from the dashboard.
 
-
 Place the following in `/var/lib/matchbox/groupss/default.json`:
 
 ### Create the Group
@@ -64,6 +64,7 @@ Place the following in `/var/lib/matchbox/groupss/default.json`:
   "profile": "default"
 }
 ```
+
 {{% /tab %}}
 {{< /tabpane >}}
 

--- a/content/docs/how-to-guides/how-to-register-a-gcp-instance/index.md
+++ b/content/docs/how-to-guides/how-to-register-a-gcp-instance/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Register a GCP Instance"
+title: "Register a GCP Instance"
 description: "A guide on how to register a GCP instance with Omni."
 date: 2022-11-23T15:35:30-07:00
 draft: false

--- a/content/docs/how-to-guides/how-to-register-a-hetzner-server/index.md
+++ b/content/docs/how-to-guides/how-to-register-a-hetzner-server/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Register a Hetzner Server
+title: Register a Hetzner Server
 description: "A guide on how to register a Hetzner server with Omni."
 date: 2022-11-16T12:46:28-08:00
 draft: false

--- a/content/docs/how-to-guides/how-to-register-a-raspberry-pi-4-model-b.md
+++ b/content/docs/how-to-guides/how-to-register-a-raspberry-pi-4-model-b.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Register a Raspberry Pi 4 Model B"
+title: "Register a Raspberry Pi 4 Model B"
 description: "A guide on how to register a Raspberry Pi 4 Model B with Omni."
 date: 2022-10-30T16:06:29-07:00
 draft: true

--- a/content/docs/how-to-guides/how-to-register-an-aws-ec2-instance.md
+++ b/content/docs/how-to-guides/how-to-register-an-aws-ec2-instance.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Register an AWS EC2 Instance"
+title: "Register an AWS EC2 Instance"
 description: "A guide on how to register an AWS EC2 instance with Omni."
 date: 2022-10-29T15:35:30-07:00
 draft: false

--- a/content/docs/how-to-guides/how-to-register-an-azure-instance/index.md
+++ b/content/docs/how-to-guides/how-to-register-an-azure-instance/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Register an Azure Instance"
+title: "Register an Azure Instance"
 description: "A guide on how to register an Azure instance with Omni."
 date: 2023-05-1T15:35:30-07:00
 draft: false
@@ -103,6 +103,7 @@ az image create \
 
 {{% tab header="CLI" %}}
 Creating an instance requires setting the os-disk-size property, which is easiest to achieve via the CLI:
+
 ```bash
 az vm create \
     --name azure-worker \
@@ -111,7 +112,7 @@ az vm create \
     --admin-username talos \
     --generate-ssh-keys \
     --verbose \
-    --os-disk-size-gb 20 
+    --os-disk-size-gb 20
 ```
 
 {{% /tab %}}

--- a/content/docs/how-to-guides/how-to-restore-cluster-etcd/index.md
+++ b/content/docs/how-to-guides/how-to-restore-cluster-etcd/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Restore Etcd of a Cluster Managed by Cluster Templates to an Earlier Snapshot
+title: Restore Etcd of a Cluster Managed by Cluster Templates to an Earlier Snapshot
 description: A guide on how to restore a cluster's etcd to an earlier snapshot.
 draft: false
 weight: 40
@@ -9,6 +9,7 @@ This guide shows you how to restore a cluster's etcd to an earlier snapshot.
 This is useful when you need to revert a cluster to an earlier state.
 
 This tutorial has the following requirements:
+
 - The CLI tool `omnictl` must be installed and configured.
 - The cluster which you want to restore **must still exist** (not deleted from Omni) and have backups in the past.
 - The cluster **must be managed using cluster templates** (not via the UI).
@@ -16,11 +17,13 @@ This tutorial has the following requirements:
 ## Finding the Cluster's UUID
 
 To find the cluster's UUID, run the following command, replacing `my-cluster` with the name of your cluster:
+
 ```bash
 omnictl get clusteruuid my-cluster
 ```
 
 The output will look like this:
+
 ```text
 NAMESPACE   TYPE          ID              VERSION   UUID
 default     ClusterUUID   my-cluster      1         bb874758-ee54-4d3b-bac3-4c8349737298
@@ -31,11 +34,13 @@ Note the `UUID` column, which contains the cluster's UUID.
 ## Finding the Snapshot to Restore
 
 List the available snapshots for the cluster:
+
 ```bash
 omnictl get etcdbackup -l omni.sidero.dev/cluster=my-cluster
 ```
 
 The output will look like this:
+
 ```text
 NAMESPACE   TYPE         ID                         VERSION     CREATED AT                         SNAPSHOT
 external    EtcdBackup   my-cluster-1701184522   undefined   {"nanos":0,"seconds":1701184522}   FFFFFFFF9A99FBF6.snapshot
@@ -52,6 +57,7 @@ This will take the cluster into the non-bootstrapped state.
 Only then we can create the new control plane with the restored etcd.
 
 Use the following command to delete the control plane, replacing `my-cluster` with the name of your cluster:
+
 ```bash
 omnictl delete machineset my-cluster-control-planes
 ```
@@ -88,6 +94,7 @@ machines:
 ## Syncing the Template
 
 To sync the template, run the following command:
+
 ```bash
 omnictl cluster template sync -f template-manifest.yaml
 omnictl cluster template status -f template-manifest.yaml

--- a/content/docs/how-to-guides/how-to-scale-down-a-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-scale-down-a-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Scale Down a Cluster
+title: Scale Down a Cluster
 description: "A guide on how to scale down a cluster with Omni."
 date: 2023-02-22T12:46:28-08:00
 draft: false
@@ -16,3 +16,4 @@ Now, select "Destroy" from the menu under the elipsis:
 {{< /imgproc >}}
 
 The cluster will now scale down.
+

--- a/content/docs/how-to-guides/how-to-scale-up-a-cluster/index.md
+++ b/content/docs/how-to-guides/how-to-scale-up-a-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to Scale Up a Cluster
+title: Scale Up a Cluster
 description: "A guide on how to scale up a cluster with Omni."
 date: 2023-02-22T12:46:28-08:00
 draft: false
@@ -13,9 +13,9 @@ From the "Cluster Overview" tab, click the "Add Machines" button in the sidebar 
 {{< imgproc 1.png Resize "900x" >}}
 {{< /imgproc >}}
 
-
 From the list of available machines that is shown, identify the machine or machines you wish to add, and then click "ControlPlane" or "Worker", to add the machine with that role.
 You may add multiple machines in one operation.
 Click "Add Machines" when all machines have been selected to be added.
 
 The cluster will now scale up.
+

--- a/content/docs/how-to-guides/how-to-use-kubectl-with-omni/index.md
+++ b/content/docs/how-to-guides/how-to-use-kubectl-with-omni/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Use Kubectl With Omni"
+title: "Use Kubectl With Omni"
 date: 2022-11-17T10:14:18-08:00
 draft: false
 weight: 90


### PR DESCRIPTION
Minor markdown linting and formatting