### PR TITLE
fix: correct path to matchbox groups directory

### DIFF
--- a/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-pxe/index.md
+++ b/content/docs/how-to-guides/how-to-register-a-bare-metal-machine-pxe/index.md
@@ -53,7 +53,7 @@ Place the following in `/var/lib/matchbox/profiles/default.json`:
 
 Update `siderolink.api`, `talos.events.sink`, and `talos.logging.kernel` with the kerenl parameters copied from the dashboard.
 
-Place the following in `/var/lib/matchbox/groupss/default.json`:
+Place the following in `/var/lib/matchbox/groups/default.json`:
 
 ### Create the Group
 


### PR DESCRIPTION
[Matchbox concepts](https://matchbox.psdn.io/matchbox/#groups) shows the path to the directory should be `/var/lib/matchbox/groups/`, not `/var/lib/matchbox/groupss/`.