### PR TITLE
Corrected URL to WSOA to avoid 404

### DIFF
--- a/content/docs/how-to-guides/self-hosted/how-to-deploy-omni-on-prem/index.md
+++ b/content/docs/how-to-guides/self-hosted/how-to-deploy-omni-on-prem/index.md
@@ -83,7 +83,7 @@ Take note of the following information from the Auth0 application:
 - [EntraID/Azure AD](../how-to-configure-entraid-for-omni)
 - [Keycloak](../how-to-configure-keycloak-for-omni)
 - [Okta](../how-to-configure-okta-for-omni)
-- [Workspace ONE Access](../how-to-configure-wsoa-for-omni)
+- [Workspace ONE Access](../../saml-and-omni/how-to-configure-wsoa-for-omni)
 
 ## Create Etcd Encryption Key
 


### PR DESCRIPTION
There was a missing directory level on the WSOA link in the existing docs.