### PR TITLE
Add Instructions for Manual Configuration Setup

### DIFF
--- a/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
+++ b/content/docs/how-to-guides/how-to-install-and-configure-omnictl/index.md
@@ -24,6 +24,10 @@ Add the downloaded `omniconfig.yaml` to the default location to use it with `omn
 ```bash
 cp omniconfig.yaml ~/.config/omni/config
 ```
+Set the `OMNICONFIG` environment variable to point to your configuration file:
+```bash
+export OMNICONFIG=~/.config/omni/config/omniconfig.yaml  
+```
 
 If you would like to merge the `omniconfig.yaml` with an existing configuration, use the following command:
 


### PR DESCRIPTION
This PR includes instructions for manually setting the configuration for omnictl. Currently, the merge command is not functioning on Linux machines.